### PR TITLE
fix for #3

### DIFF
--- a/MSCL/Jamfile
+++ b/MSCL/Jamfile
@@ -71,7 +71,7 @@ python-extension _mscl
 	boostLibs
 :	<include>source/mscl/Wrapper/
 	<swig-options>-python
-	<swig-options>"-outdir $(SWIG_PYTHON)"
+	<swig-options>"-outdir \"$(SWIG_PYTHON)\""
 	<toolset>gcc:<swig-options>-DUNIX_SOCKETS
 	<toolset>gcc:<define>UNIX_SOCKETS
 ;
@@ -83,7 +83,7 @@ python-extension _mscl-dynamic
 	boostLibs
 :	<include>source/mscl/Wrapper/
 	<swig-options>-python
-	<swig-options>"-outdir $(SWIG_PYTHON)"
+	<swig-options>"-outdir \"$(SWIG_PYTHON)\""
 	<toolset>gcc:<swig-options>-DUNIX_SOCKETS
 	<toolset>gcc:<define>UNIX_SOCKETS
 ;

--- a/MSCL/swig.jam
+++ b/MSCL/swig.jam
@@ -12,5 +12,5 @@ feature.feature swig-options : : free ;
 toolset.flags swig.swig OPTIONS <swig-options> ;
 actions swig
 {
-	swig -c++ $(OPTIONS) -o $(<) $(>)
+	swig -c++ $(OPTIONS) -o "$(<)" "$(>)"
 }


### PR DESCRIPTION
This fix escapes the possible spaces in the file paths when trying to compile the Python wrapper