### PR TITLE
Add some sample code for ParseData.cpp under Linux

### DIFF
--- a/MSCL_Examples/Inertial/C++/MSCL_Inertial_Example_C++/ParseData/CMakeLists.txt
+++ b/MSCL_Examples/Inertial/C++/MSCL_Inertial_Example_C++/ParseData/CMakeLists.txt
@@ -1,0 +1,21 @@
+project(parsedata)
+ 
+cmake_minimum_required(VERSION 3.5)
+ 
+find_package(Boost REQUIRED filesystem system)
+ 
+set(CMAKE_CXX_FLAGS "-std=c++0x ${CMAKE_CXX_FLAGS} -g -ftest-coverage -fprofile-arcs")
+
+
+set(MSCL_INC "(path to mscl)/MSCL/MSCL/source") 
+
+include_directories(${MSCL_INC})
+ 
+ 
+LINK_DIRECTORIES("(path to mscl)/MSCL/Output/C++/Release")
+ 
+SET(PARSE_SRCS ParseData.cpp)
+ 
+LINK_LIBRARIES("libmscl.so")
+ 
+ADD_EXECUTABLE(parse ${PARSE_SRCS})

--- a/MSCL_Examples/Inertial/C++/MSCL_Inertial_Example_C++/ParseData/ParseData.cpp
+++ b/MSCL_Examples/Inertial/C++/MSCL_Inertial_Example_C++/ParseData/ParseData.cpp
@@ -8,6 +8,8 @@
 #include <iostream>
 using namespace std;
 
+#include "mscl/Types.h"
+#include "mscl/MicroStrain/MIP/MipTypes.h"
 #include "mscl/Communication/Connection.h"
 #include "mscl/MicroStrain/Inertial/InertialNode.h"
 #include "mscl/Exceptions.h"
@@ -15,7 +17,7 @@ using namespace std;
 int main(int argc, char **argv)
 {
 	//TODO: change these constants to match your setup
-	const string COM_PORT = "COM15";
+	const string COM_PORT = "COM15"; //linux: /dev/ttyACM0
 
 	try
 	{
@@ -24,6 +26,25 @@ int main(int argc, char **argv)
 
 		//create an InertialNode with the connection
 		mscl::InertialNode node(connection);
+
+        //Put the Inertial Node into its idle state
+        //  (This is not required but reduces the parsing
+        //  burden during initialization and makes visual
+        //  confirmation of the commands easier.)
+        node.setToIdle();
+
+        //build up the channels to set
+        mscl::MipChannels sensorChs;
+
+        //setup Scaled Accelerometer Vector
+        sensorChs.push_back(mscl::MipChannel(mscl::MipTypes::CH_FIELD_SENSOR_SCALED_ACCEL_VEC, mscl::SampleRate::Hertz(100)));
+        //setup Scaled Gyro Vector
+        sensorChs.push_back(mscl::MipChannel(mscl::MipTypes::CH_FIELD_SENSOR_SCALED_GYRO_VEC, mscl::SampleRate::Hertz(100)));
+        //set the active channels for the Sensor category on the Node 
+        node.setActiveChannelFields(mscl::MipTypes::CLASS_AHRS_IMU, sensorChs);
+
+        //start sampling on the Sensor category of the Node
+        node.enableDataStream(mscl::MipTypes::CLASS_AHRS_IMU);
 
 		//endless loop of reading in data
 		while(true)


### PR DESCRIPTION
Add examples:
1. Example `CMakeLists.txt` for building ParseData.cpp under Linux environment.
2. Setup sensor before receiving data.

Under windows env, the ParseData.cpp work fine, since LORD provide MIP Monitor GUI to setup sensor.
However, we don't have any GUI tool to setup Inertial sensor message.
I think it would be more clear if we add the setup code to the ParseData.cpp example.
Then user won't getting confused that sensor didn't output anything on screen.