### PR TITLE
Switch away from a deprecated Boost macro API.

### DIFF
--- a/MSCL/source/mscl/Endianness.h
+++ b/MSCL/source/mscl/Endianness.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <boost/detail/endian.hpp>
+#include <boost/predef/other/endian.h>
 #include <algorithm>
 
 namespace mscl
@@ -82,7 +82,7 @@ template<typename StaticType>
 inline StaticType SystemEndian_To_LittleEndian(StaticType val);
 
 
-#ifdef BOOST_LITTLE_ENDIAN
+#if BOOST_ENDIAN_LITTLE_BYTE
 // Little endian system
 
 template<typename StaticType>

--- a/MSCL/source/stdafx.h
+++ b/MSCL/source/stdafx.h
@@ -13,10 +13,10 @@
 #include <boost/circular_buffer.hpp>                               //for boost circular buffer
 #include <boost/date_time.hpp>                                     //for boost::posix_time::from_time_t
 #include <boost/date_time/posix_time/posix_time_duration.hpp>      //for boost::posix_time::nanosec
-#include <boost/date_time/posix_time/ptime.hpp>                    //for boost ptime    
-#include <boost/detail/endian.hpp>                                 //for endianess
+#include <boost/date_time/posix_time/ptime.hpp>                    //for boost ptime
 #include <boost/numeric/conversion/cast.hpp>                       //for boost::numeric_cast
 #include <boost/optional.hpp>                                      //for boost::optional
+#include <boost/predef/other/endian.h>                             //for endianess
 #include <boost/utility/binary.hpp>                                //for BOOST_BINARY
 
 #include <algorithm>                                               //for std::min, std::replace


### PR DESCRIPTION
The BOOST_LITTLE_ENDIAN macro is an internal implementation detail of boost, removed in Boost 1.74.  Change this code to use the boost predef library, which provides a supported version of the same feature test macro functionality.