### PR TITLE
Removes reserved value when reading CMD_EF_LEVER_ARM_OFFSET_REF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ ___
     - Updated DeviceCommPort::Protocol to use correct enum values
     - Increased timeout for GNSS config export
     - Moved CV7-GNSS/INS to correction source for PPS
+    - Removes reserved value when reading CMD_EF_LEVER_ARM_OFFSET_REF
 - Appends -dirty to MSCL_GIT_COMMIT if there are changes in the repository
 
 ## 67.1.0 - 2025-03-27

--- a/MSCL/source/mscl/MicroStrain/Inertial/InertialNode.cpp
+++ b/MSCL/source/mscl/MicroStrain/Inertial/InertialNode.cpp
@@ -1173,9 +1173,7 @@ namespace mscl
 
     PositionOffset InertialNode::getLeverArmReferenceOffset() const
     {
-        const MipFieldValues data = m_impl->get(MipTypes::CMD_EF_LEVER_ARM_OFFSET_REF, {
-            Value::UINT8(1) // reserved, placeholder source value
-        });
+        const MipFieldValues data = m_impl->get(MipTypes::CMD_EF_LEVER_ARM_OFFSET_REF);
 
         // skip first element - reserved, placeholder source value
         return PositionOffset(data[1].as_float(), data[2].as_float(), data[3].as_float());


### PR DESCRIPTION
This reserved value was never required to be sent and causes issues on some devices when it is sent