### PR TITLE
Increases GNSS timeouts to allow time for responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ ___
     - Added GNSS signal config options for CV7-GNSS/INS
     - Added DeviceCommPort::InterfaceId with current interface ID options
     - Updated DeviceCommPort::Protocol to use correct enum values
-    - Increased timeout for GNSS config export
+    - Increased timeout for GNSS signal config and SBAS settings
     - Moved CV7-GNSS/INS to correction source for PPS
     - Removes reserved value when reading CMD_EF_LEVER_ARM_OFFSET_REF
 - Appends -dirty to MSCL_GIT_COMMIT if there are changes in the repository

--- a/MSCL/source/mscl/MicroStrain/Inertial/InertialNode.cpp
+++ b/MSCL/source/mscl/MicroStrain/Inertial/InertialNode.cpp
@@ -353,7 +353,14 @@ namespace mscl
 
     void InertialNode::setSBASSettings(const SBASSettingsData& dataToUse)
     {
+        // Increase the timeout for this command to account for the Ublox response
+        const uint64_t originalTimeout = timeout();
+        timeout(originalTimeout + 600);
+
         m_impl->setSBASSettings(dataToUse);
+
+        // Reset the timeout
+        timeout(originalTimeout);
     }
 
     SBASSettingsData InertialNode::getSBASSettings()
@@ -1232,6 +1239,10 @@ namespace mscl
 
     void InertialNode::setGnssSignalConfig(GnssSignalConfiguration config)
     {
+        // Increase the timeout for the ublox response
+        const uint64_t originalTimeout = timeout();
+        timeout(originalTimeout + 600);
+
         m_impl->set(MipTypes::CMD_GNSS_SIGNAL_CONFIG, {
             Value::UINT8(config.gpsSignalValue()),
             Value::UINT8(config.glonassSignalValue()),
@@ -1239,6 +1250,9 @@ namespace mscl
             Value::UINT8(config.beidouSignalValue()),
             Value::UINT32(0)
         });
+
+        // Reset the timeout
+        timeout(originalTimeout);
     }
 
     GnssSpartnConfiguration InertialNode::getGnssSpartnConfig() const

--- a/MSCL/source/mscl/MicroStrain/MIP/MipNode_Impl.cpp
+++ b/MSCL/source/mscl/MicroStrain/MIP/MipNode_Impl.cpp
@@ -768,7 +768,6 @@ namespace mscl
 
                 break;
             }
-            case MipTypes::CMD_EF_LEVER_ARM_OFFSET_REF:
             case MipTypes::CMD_EF_SPEED_MEASUREMENT_OFFSET:
             {
                 MipFieldValues reserved = { Value::UINT8(1) };


### PR DESCRIPTION
Also removes extra indicator for the filter lever arm offset when exporting config